### PR TITLE
Remove the "override" for src/index.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,13 +17,6 @@
 
 	"overrides": [
 		{
-			"files": "src/index.js",
-
-			"parserOptions": {
-				"sourceType": "module"
-			}
-		},
-		{
 			"files": "test/**/*.js",
 
 			"env": {


### PR DESCRIPTION
There is nothing special about this one anymore: It's a module, just like all
other code.

---
This is a follow-up to https://github.com/Collaborne/tasks-scheduler/commit/6bca467cbeed852f777e5218fd038289820083fb, see https://github.com/Collaborne/tasks-scheduler/commit/31d4c62dad4d9d6c35bc592ea0d684f9094c3394#r27863074.